### PR TITLE
Implement Tumblr CSS map utilities

### DIFF
--- a/unfucker.js
+++ b/unfucker.js
@@ -150,7 +150,7 @@ getCssMapUtilities().then($unfuck);
 
 window.addEventListener('locationchange', function(){
     console.log("locationchange event occured, unfucking page");
-    window.setTimeout($unfuck, 200);
+    window.setTimeout(getCssMapUtilities().then($unfuck), 200);
 });
 
 async function getCssMapUtilities () {

--- a/unfucker.js
+++ b/unfucker.js
@@ -15,7 +15,7 @@
 
 var $ = window.jQuery;
 
-function $unfuck () {
+function $unfuck ({ keyToClasses, keyToCss }) {
     if ($(".hlDot").length) {
         console.log("no need to unfuck");
         return
@@ -97,7 +97,7 @@ function $unfuck () {
     console.log("dashboard fixed!");
 }
 
-$(document).ready($unfuck);
+getCssMapUtilities().then($unfuck);
 
 ;(function() {
     var pushState = history.pushState;
@@ -124,3 +124,16 @@ window.addEventListener('locationchange', function(){
     console.log("locationchange event occured, unfucking page");
     window.setTimeout($unfuck, 200);
 });
+
+async function getCssMapUtilities () {
+    let retries = 0;
+    while (retries++ < 1000 && (typeof tumblr === "undefined" || typeof tumblr.getCssMap === "undefined")) {
+        await new Promise((resolve) => setTimeout(resolve));
+    }
+    const cssMap = await tumblr.getCssMap();
+    const keyToClasses = (...keys) => keys.flatMap(key => cssMap[key]).filter(Boolean);
+    const keyToCss = (...keys) => `:is(${keyToClasses(...keys).map(className => `.${className}`).join(", ")})`;
+    return { keyToClasses, keyToCss };
+}
+
+getCssMapUtilities().then($unfuck);

--- a/unfucker.js
+++ b/unfucker.js
@@ -14,7 +14,7 @@
 
 var $ = window.jQuery;
 
-function $unfuck ({ keyToClasses, keyToCss }) {
+function $unfuck () {
     if ($(".hlDot").length) {
         console.log("no need to unfuck");
         return
@@ -66,15 +66,5 @@ function $unfuck ({ keyToClasses, keyToCss }) {
     $create.find("a").eq(0).html(`<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" role="presentation"><use href="#managed-icon__post"></use></svg>`);
 }
 
-async function getCssMapUtilities () {
-    let retries = 0;
-    while (retries++ < 1000 && (typeof tumblr === "undefined" || typeof tumblr.getCssMap === "undefined")) {
-        await new Promise((resolve) => setTimeout(resolve));
-    }
-    const cssMap = await tumblr.getCssMap();
-    const keyToClasses = (...keys) => keys.flatMap(key => cssMap[key]).filter(Boolean);
-    const keyToCss = (...keys) => `:is(${keyToClasses(...keys).map(className => `.${className}`).join(", ")})`;
-    return { keyToClasses, keyToCss };
-}
 
-getCssMapUtilities().then($unfuck);
+$(document).ready($unfuck);

--- a/unfucker.js
+++ b/unfucker.js
@@ -163,5 +163,3 @@ async function getCssMapUtilities () {
     const keyToCss = (...keys) => `:is(${keyToClasses(...keys).map(className => `.${className}`).join(", ")})`;
     return { keyToClasses, keyToCss };
 }
-
-getCssMapUtilities().then($unfuck);

--- a/unfucker.js
+++ b/unfucker.js
@@ -14,7 +14,7 @@
 
 var $ = window.jQuery;
 
-function $unfuck () {
+function $unfuck ({ keyToClasses, keyToCss }) {
     if ($(".hlDot").length) {
         console.log("no need to unfuck");
         return
@@ -66,5 +66,15 @@ function $unfuck () {
     $create.find("a").eq(0).html(`<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" role="presentation"><use href="#managed-icon__post"></use></svg>`);
 }
 
+async function getCssMapUtilities () {
+    let retries = 0;
+    while (retries++ < 1000 && (typeof tumblr === "undefined" || typeof tumblr.getCssMap === "undefined")) {
+        await new Promise((resolve) => setTimeout(resolve));
+    }
+    const cssMap = await tumblr.getCssMap();
+    const keyToClasses = (...keys) => keys.flatMap(key => cssMap[key]).filter(Boolean);
+    const keyToCss = (...keys) => `:is(${keyToClasses(...keys).map(className => `.${className}`).join(", ")})`;
+    return { keyToClasses, keyToCss };
+}
 
-$(document).ready($unfuck);
+getCssMapUtilities().then($unfuck);

--- a/unfucker.js
+++ b/unfucker.js
@@ -15,24 +15,24 @@
 var $ = window.jQuery;
 
 function $unfuck ({ keyToClasses, keyToCss }) {
-    if ($(keyToCss("headerWrapper")).length) {
+    if ($(".hlDot").length) {
         console.log("no need to unfuck");
         return
     }
-    var $aside = $(keyToCss("sidebar")).eq(0);
-    var $search = $aside.find(keyToCss("searchSidebarItem")).eq(0);
-    var $nav = $(keyToCss("navigationLinks")).eq(0);
-    var $content = $(keyToCss("main")).eq(0);
-    var $main = $(keyToCss("newDesktopLayout")).eq(0);
-    var $bar = $("<div>", {class: keyToClasses("headerWrapper")[0]});
-    var $logo = $(keyToCss("logoContainer")).eq(0);
-    var $footer = $(keyToCss("usesNewDimensions")).eq(0);
-    var $create = $(keyToCss("createPost")).eq(0);
+    var $aside = $(".e1knl").eq(0);
+    var $search = $aside.find(".N5wJr").eq(0);
+    var $nav = $(".gM9qK").eq(0);
+    var $content = $(".lSyOz").eq(0);
+    var $main = $(".ZkG01").eq(0);
+    var $bar = $("<div>", {class: "hlDot"});
+    var $logo = $(".Gav7q").eq(0);
+    var $footer = $(".j_AvJ").eq(0);
+    var $create = $(".jGgIg").eq(0);
     $aside.detach();
     $search.detach();
     $create.detach();
     $bar.css({display: "flex"});
-    $(keyToCss("bluespaceLayout")).prepend($bar);
+    $(".D5eCV").prepend($bar);
     $logo.detach()
     $bar.append($logo);
     $bar.append($search);
@@ -42,24 +42,24 @@ function $unfuck ({ keyToClasses, keyToCss }) {
     $main.append($aside)
     $logo.css("margin-left", "100px");
     $search.css("max-width", "550px");
-    $(keyToCss("mainContentWrapper")).eq(0).remove();
-    $(keyToCss("navigationWrapper")).eq(0).remove();
-    $(keyToCss("navigation")).css({border: "none"});
+    $("._3xgk").eq(0).remove();
+    $(".h_Erh").eq(0).remove();
+    $(".FA5JM").css({border: "none"});
     $main.css({border: "none", marginTop: "40px"});
     $aside.css({marginLeft: "50px"})
     $aside.children().eq(0).css({position: "fixed", width: "320px"});
-    $(`${keyToCss("about")}${keyToCss("inSidebar")}${keyToCss("usesNewDimensions")}`).css("position", "fixed");
-    $(`${keyToCss("post")} ${keyToCss("stickyContainer")} ${keyToCss("avatar")}${keyToCss("newDesktopLayout")}`).css("top", "calc(70px + var(--dashboard-tabs-header-height,0px))");
-    $(keyToCss("searchShadow")).css("background", "none");
+    $(".m8mN_._qHCt.j_AvJ").css("position", "fixed");
+    $(".FtjPK .AD_w7 .JZ10N.y0ud2").css("top", "calc(70px + var(--dashboard-tabs-header-height,0px))");
+    $(".zmjaW").css("background", "none");
     $nav.css({display: "flex", justifyContent: "flex-end", flexBasis: "100%", marginBottom: "0px", marginTop: "8px"});
     $nav.children(":nth-child(2),:nth-child(10),:nth-child(11),:nth-child(12)").remove();
     $nav.find("svg").css("scale", "1.4");
-    $(`${keyToCss("startChildWrapper")} + ${keyToCss("navInfo")}`).remove();
-    $(keyToCss("subNav")).css({height: "800px", overflowY: "scroll", background: "RGB(var(--white))", scrollbarColor: "rgba(var(--black),.4)rgba(var(--white),.1)", color: "RGB(var(--black))", position: "absolute", borderRadius: "4px", marginTop: "48px"});
-    $(`${keyToCss("subNav")} *`).css({color: "RGB(var(--black))"});
-    $(`${keyToCss("subNav")} li`).css({listStyleType: "none", borderBottom: "rgba(var(--black),.07)"});
+    $(".kn4U3 + .a132D").remove();
+    $(".jL4Qq").css({height: "800px", overflowY: "scroll", background: "RGB(var(--white))", scrollbarColor: "rgba(var(--black),.4)rgba(var(--white),.1)", color: "RGB(var(--black))", position: "absolute", borderRadius: "4px", marginTop: "48px"});
+    $(".jL4Qq *").css({color: "RGB(var(--black))"});
+    $(".jL4Qq li").css({listStyleType: "none", borderBottom: "rgba(var(--black),.07)"});
     $("#settings_subnav").css("height", "fit-content");
-    $(keyToCss("navSubHeader")).replaceWith(`<div class="${keyToClasses("heading")[0]}" style="display: flex;align-items: center;justify-content: space-between;background: rgba(var(--black),.07);height: 36px;padding: 4px 12px 4px 12px;color: rgba(var(--black),.65);"><h3>Blogs</h3><a class="${keyToClasses("headingLink")[0]}" style="text-decoration: none;" href="/new/blog">+ New</a></div>`);
+    $(".h8SQv").replaceWith(`<div class="l463r" style="display: flex;align-items: center;justify-content: space-between;background: rgba(var(--black),.07);height: 36px;padding: 4px 12px 4px 12px;color: rgba(var(--black),.65);"><h3>Blogs</h3><a class="Oyvhq" style="text-decoration: none;" href="/new/blog">+ New</a></div>`);
     $footer.css({position: "fixed", height: "20px", bottom: "0px", right: "50px"});
     $create.css({width: "44px", marginRight: "100px", marginLeft: "10px"});
     $create.children().eq(0).css({borderRadius: "3px"});

--- a/unfucker.js
+++ b/unfucker.js
@@ -16,7 +16,7 @@
 var $ = window.jQuery;
 
 function $unfuck ({ keyToClasses, keyToCss }) {
-    if ($(".hlDot").length) {
+    if ($(keyToCss("headerWrapper")).length) {
         console.log("no need to unfuck");
         return
     }
@@ -34,31 +34,59 @@ function $unfuck ({ keyToClasses, keyToCss }) {
             continue;
         }
     }
-    var $nav = $(".gM9qK").eq(0);
+    var $nav = $(keyToCss("navigationLinks")).eq(0);
     var $content = ""
-    var $main = $(".ZkG01").eq(0);
-    var $bar = $("<div>", {class: "hlDot"});
-    var $logo = $(".Gav7q").eq(0);
-    var $create = $(".jGgIg").eq(0);
+    var $main = $(keyToCss("newDesktopLayout")).eq(0);
+    var $bar = $("<div>", {class: keyToClasses("headerWrapper").join(" ")});
+    var $logo = $(keyToCss("logoContainer")).eq(0);
+    var $create = $(keyToCss("createPost")).eq(0);
     var $search = ""
     $create.detach();
     $bar.css({display: "flex"});
-    $(".D5eCV").prepend($bar);
+    $(keyToCss("bluespaceLayout")).prepend($bar);
     $logo.detach()
     $bar.append($logo);
     if (test) {
-        var $aside = $(".e1knl").eq(0);
-        $search = $(".N5wJr").eq(0);
-        $content = $(".lSyOz").eq(0);
+        var $aside = $(keyToCss("sidebar")).eq(0);
+        $search = $(keyToCss("searchSidebarItem")).eq(0);
+        $content = $(keyToCss("main")).eq(0);
         $aside.detach();
         $main.append($aside)
         $aside.css({marginLeft: "50px", position: "sticky", top: "54px", height: "fit-content"})
         $aside.children().eq(0).css({width: "320px"});
-        $(".m8mN_._qHCt.j_AvJ").css({position: "fixed", height: "20px", bottom: "0px"});
+        $(`${keyToCss("about")}${keyToCss("inSidebar")}${keyToCss("usesNewDimensions")}`).css({position: "fixed", height: "20px", bottom: "0px"});
     }
     else {
-        $content = $(".RkANE").eq(0);
-        $search = $(`<div class="N5wJr" style="max-width: 550px; width: 100%; padding: 14px 8px 0px 8px;"><div class="Mw2UR"><span data-testid="controlled-popover-wrapper" class="BPf9u"><span class="BPf9u"><form method="GET" action="/search" role="search" class="aogHd"><div class="oPa7v"><div class="Z3WPg"><svg xmlns="http://www.w3.org/2000/svg" height="18" width="18" role="presentation"><use href="#managed-icon__search"></use></svg></div><input name="q" type="text" autocomplete="off" aria-label="Search" class="NaqPB" placeholder="Search Tumblr" autocapitalize="sentences" value=""></div></form></span></span></div></div>`)
+        $content = $(keyToCss("container")).eq(0);
+        $search = $(`
+            <div class="${keyToClasses("searchSidebarItem").join(" ")}" style="max-width: 550px; width: 100%; padding: 14px 8px 0px 8px" >
+                <div class="${keyToClasses("formContainer").join(" ")}">
+                <span data-testid="controlled-popover-wrapper" class="${keyToClasses("targetWrapper").join(" ")}">
+                    <span class="${keyToClasses("targetWrapper").join(" ")}">
+                    <form method="GET" action="/search" role="search" class="${keyToClasses("form").join(" ")}">
+                        <div class="${keyToClasses("searchbarContainer").join(" ")}">
+                        <div class="${keyToClasses("searchIcon").join(" ")}">
+                            <svg xmlns="http://www.w3.org/2000/svg" height="18" width="18" role="presentation" >
+                            <use href="#managed-icon__search"></use>
+                            </svg>
+                        </div>
+                        <input
+                            name="q"
+                            type="text"
+                            autocomplete="off"
+                            aria-label="Search"
+                            class="${keyToClasses("searchbar").join(" ")}"
+                            placeholder="Search Tumblr"
+                            autocapitalize="sentences"
+                            value=""
+                        />
+                        </div>
+                    </form>
+                    </span>
+                </span>
+                </div>
+            </div>
+        `)
     }
     if (compare === "search" || compare === "tagged") {
         $content.css("max-width", "fit-content");
@@ -71,26 +99,26 @@ function $unfuck ({ keyToClasses, keyToCss }) {
     $main.prepend($content)
     $logo.css("margin-left", "100px");
     $search.css("max-width", "550px");
-    $("._3xgk").eq(0).remove();
-    $(".h_Erh").eq(0).remove();
-    $(".FA5JM").css({border: "none"});
+    $(keyToCss("mainContentWrapper")).eq(0).remove();
+    $(keyToCss("navigationWrapper")).eq(0).remove();
+    $(keyToCss("navigation")).css({border: "none"});
     $main.css({border: "none", marginTop: "40px"});
-    $(".FtjPK .AD_w7 .JZ10N.y0ud2").css("top", "calc(70px + var(--dashboard-tabs-header-height,0px))");
-    $(".zmjaW").css("background", "none");
+    $(`${keyToCss("post")} ${keyToCss("stickyContainer")} ${keyToCss("avatar")}${keyToCss("newDesktopLayout")}`).css("top", "calc(70px + var(--dashboard-tabs-header-height,0px))");
+    $(keyToCss("searchShadow")).css("background", "none");
     $nav.css({display: "flex", justifyContent: "flex-end", flexBasis: "100%", marginBottom: "0px", marginTop: "8px"});
     $nav.children(":nth-child(2),:nth-child(10),:nth-child(11),:nth-child(12)").remove();
     $nav.find("svg").css("scale", "1.4");
-    $(".kn4U3 + .a132D").remove();
-    $(".jkWYb").css("list-style-type", "none");
-    $(".jL4Qq").css({height: "800px", overflowY: "scroll", background: "RGB(var(--white))", scrollbarColor: "rgba(var(--black),.4)rgba(var(--white),.1)", color: "RGB(var(--black))", position: "absolute", borderRadius: "4px", marginTop: "48px"});
-    $(".jL4Qq *").css({color: "RGB(var(--black))"});
-    var $navli = $(".jL4Qq > .IYrO9,.kbIQf li");
+    $(`${keyToCss("startChildWrapper")} + ${keyToCss("navInfo")}`).remove();
+    $(keyToCss("blogTile")).css("list-style-type", "none");
+    $(keyToCss("subNav")).css({height: "800px", overflowY: "scroll", background: "RGB(var(--white))", scrollbarColor: "rgba(var(--black),.4)rgba(var(--white),.1)", color: "RGB(var(--black))", position: "absolute", borderRadius: "4px", marginTop: "48px"});
+    $(`${keyToCss("subNav")} *`).css({color: "RGB(var(--black))"});
+    var $navli = $(`${keyToCss("subNav")} > ${keyToCss("navItem")}, ${keyToCss("accountStats")} li`);
     $navli.css({listStyleType: "none", borderBottom: "1px solid rgba(var(--black),.07)"});
     $navli.on("mouseenter", function() {$(this).css("background-color", "rgba(var(--black),.07)")});
     $navli.on("mouseleave", function() {$(this).css("background-color", "rgb(var(--white))")});
     $("#managed-icon__caret-thin").css("--icon-color-primary", "rgba(var(--black),.65)")
     $("#settings_subnav").css("height", "fit-content");
-    $(".h8SQv").replaceWith('<div class="l463r" style="display: flex;align-items: center;justify-content: space-between;background: rgba(var(--black),.07);height: 36px;padding: 4px 12px 4px 12px;color: rgba(var(--black),.65);"><h3>Blogs</h3><a class="Oyvhq" style="text-decoration: none;" href="/new/blog">+ New</a></div>');
+    $(keyToCss("navSubHeader")).replaceWith(`<div class="${keyToClasses("heading").join(" ")}" style="display: flex;align-items: center;justify-content: space-between;background: rgba(var(--black),.07);height: 36px;padding: 4px 12px 4px 12px;color: rgba(var(--black),.65);"><h3>Blogs</h3><a class="${keyToClasses("headingLink").join(" ")}" style="text-decoration: none;" href="/new/blog">+ New</a></div>`);
     $create.css({width: "44px", marginRight: "100px", marginLeft: "10px"});
     $create.children().eq(0).css({borderRadius: "3px"});
     $create.find("a").eq(0).html('<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" role="presentation"><use href="#managed-icon__post"></use></svg>');

--- a/unfucker.js
+++ b/unfucker.js
@@ -15,24 +15,24 @@
 var $ = window.jQuery;
 
 function $unfuck ({ keyToClasses, keyToCss }) {
-    if ($(".hlDot").length) {
+    if ($(keyToCss("headerWrapper")).length) {
         console.log("no need to unfuck");
         return
     }
-    var $aside = $(".e1knl").eq(0);
-    var $search = $aside.find(".N5wJr").eq(0);
-    var $nav = $(".gM9qK").eq(0);
-    var $content = $(".lSyOz").eq(0);
-    var $main = $(".ZkG01").eq(0);
-    var $bar = $("<div>", {class: "hlDot"});
-    var $logo = $(".Gav7q").eq(0);
-    var $footer = $(".j_AvJ").eq(0);
-    var $create = $(".jGgIg").eq(0);
+    var $aside = $(keyToCss("sidebar")).eq(0);
+    var $search = $aside.find(keyToCss("searchSidebarItem")).eq(0);
+    var $nav = $(keyToCss("navigationLinks")).eq(0);
+    var $content = $(keyToCss("main")).eq(0);
+    var $main = $(keyToCss("newDesktopLayout")).eq(0);
+    var $bar = $("<div>", {class: keyToClasses("headerWrapper")[0]});
+    var $logo = $(keyToCss("logoContainer")).eq(0);
+    var $footer = $(keyToCss("usesNewDimensions")).eq(0);
+    var $create = $(keyToCss("createPost")).eq(0);
     $aside.detach();
     $search.detach();
     $create.detach();
     $bar.css({display: "flex"});
-    $(".D5eCV").prepend($bar);
+    $(keyToCss("bluespaceLayout")).prepend($bar);
     $logo.detach()
     $bar.append($logo);
     $bar.append($search);
@@ -42,24 +42,24 @@ function $unfuck ({ keyToClasses, keyToCss }) {
     $main.append($aside)
     $logo.css("margin-left", "100px");
     $search.css("max-width", "550px");
-    $("._3xgk").eq(0).remove();
-    $(".h_Erh").eq(0).remove();
-    $(".FA5JM").css({border: "none"});
+    $(keyToCss("mainContentWrapper")).eq(0).remove();
+    $(keyToCss("navigationWrapper")).eq(0).remove();
+    $(keyToCss("navigation")).css({border: "none"});
     $main.css({border: "none", marginTop: "40px"});
     $aside.css({marginLeft: "50px"})
     $aside.children().eq(0).css({position: "fixed", width: "320px"});
-    $(".m8mN_._qHCt.j_AvJ").css("position", "fixed");
-    $(".FtjPK .AD_w7 .JZ10N.y0ud2").css("top", "calc(70px + var(--dashboard-tabs-header-height,0px))");
-    $(".zmjaW").css("background", "none");
+    $(`${keyToCss("about")}${keyToCss("inSidebar")}${keyToCss("usesNewDimensions")}`).css("position", "fixed");
+    $(`${keyToCss("post")} ${keyToCss("stickyContainer")} ${keyToCss("avatar")}${keyToCss("newDesktopLayout")}`).css("top", "calc(70px + var(--dashboard-tabs-header-height,0px))");
+    $(keyToCss("searchShadow")).css("background", "none");
     $nav.css({display: "flex", justifyContent: "flex-end", flexBasis: "100%", marginBottom: "0px", marginTop: "8px"});
     $nav.children(":nth-child(2),:nth-child(10),:nth-child(11),:nth-child(12)").remove();
     $nav.find("svg").css("scale", "1.4");
-    $(".kn4U3 + .a132D").remove();
-    $(".jL4Qq").css({height: "800px", overflowY: "scroll", background: "RGB(var(--white))", scrollbarColor: "rgba(var(--black),.4)rgba(var(--white),.1)", color: "RGB(var(--black))", position: "absolute", borderRadius: "4px", marginTop: "48px"});
-    $(".jL4Qq *").css({color: "RGB(var(--black))"});
-    $(".jL4Qq li").css({listStyleType: "none", borderBottom: "rgba(var(--black),.07)"});
+    $(`${keyToCss("startChildWrapper")} + ${keyToCss("navInfo")}`).remove();
+    $(keyToCss("subNav")).css({height: "800px", overflowY: "scroll", background: "RGB(var(--white))", scrollbarColor: "rgba(var(--black),.4)rgba(var(--white),.1)", color: "RGB(var(--black))", position: "absolute", borderRadius: "4px", marginTop: "48px"});
+    $(`${keyToCss("subNav")} *`).css({color: "RGB(var(--black))"});
+    $(`${keyToCss("subNav")} li`).css({listStyleType: "none", borderBottom: "rgba(var(--black),.07)"});
     $("#settings_subnav").css("height", "fit-content");
-    $(".h8SQv").replaceWith(`<div class="l463r" style="display: flex;align-items: center;justify-content: space-between;background: rgba(var(--black),.07);height: 36px;padding: 4px 12px 4px 12px;color: rgba(var(--black),.65);"><h3>Blogs</h3><a class="Oyvhq" style="text-decoration: none;" href="/new/blog">+ New</a></div>`);
+    $(keyToCss("navSubHeader")).replaceWith(`<div class="${keyToClasses("heading")[0]}" style="display: flex;align-items: center;justify-content: space-between;background: rgba(var(--black),.07);height: 36px;padding: 4px 12px 4px 12px;color: rgba(var(--black),.65);"><h3>Blogs</h3><a class="${keyToClasses("headingLink")[0]}" style="text-decoration: none;" href="/new/blog">+ New</a></div>`);
     $footer.css({position: "fixed", height: "20px", bottom: "0px", right: "50px"});
     $create.css({width: "44px", marginRight: "100px", marginLeft: "10px"});
     $create.children().eq(0).css({borderRadius: "3px"});

--- a/unfucker.js
+++ b/unfucker.js
@@ -150,7 +150,7 @@ getCssMapUtilities().then($unfuck);
 
 window.addEventListener('locationchange', function(){
     console.log("locationchange event occured, unfucking page");
-    window.setTimeout(getCssMapUtilities().then($unfuck), 200);
+    window.setTimeout(() => getCssMapUtilities().then($unfuck), 200);
 });
 
 async function getCssMapUtilities () {


### PR DESCRIPTION
Heya! Here's a sort of miniature port of the XKit Rewritten CSS selector engine, which allows one to make use of translated Tumblr CSS names instead of the random 5-character strings.

Note that there may be multiple CSS classes that translate to the same string, unfortunately, and that this makes a selector that matches any of them. For example, `keyToCss('headerWrapper')` doesn't just return `.hlDot`, but instead returns 

`:is(.jHlL6, .hlDot, .mBa_9, .GmRpU, .LjZTz)`

(that's a somewhat-new CSS selector, `:is()`, which means "match any of these").

This might lead to a few bugs!

Also, I did the replacement last night, so it's out of date and merge conflicts; whoopsie! I can fix that.