### PR TITLE
Move CSS map call to top level await

### DIFF
--- a/unfucker.js
+++ b/unfucker.js
@@ -140,7 +140,7 @@ async function $unfuck () {
 $unfuck();
 
 window.tumblr.on('navigation', () => requestAnimationFrame(function() {
-    $unfuck.catch((e) => {
+    $unfuck().catch((e) => {
         window.setTimeout(() => getCssMapUtilities().then($unfuck), 400)
     });
 }));

--- a/unfucker.js
+++ b/unfucker.js
@@ -15,7 +15,9 @@
 
 var $ = window.jQuery;
 
-function $unfuck ({ keyToClasses, keyToCss }) {
+const { keyToClasses, keyToCss } = await getCssMapUtilities();
+
+async function $unfuck () {
     if ($("#__hw").length) {
         console.log("no need to unfuck");
         return
@@ -135,11 +137,10 @@ function $unfuck ({ keyToClasses, keyToCss }) {
     console.log("dashboard fixed!");
 }
 
-getCssMapUtilities().then($unfuck);
+$unfuck();
 
 window.tumblr.on('navigation', () => requestAnimationFrame(function() {
-    getCssMapUtilities().then($unfuck)
-    .catch((e) => {
+    $unfuck.catch((e) => {
         window.setTimeout(() => getCssMapUtilities().then($unfuck), 400)
     });
 }));

--- a/unfucker.js
+++ b/unfucker.js
@@ -141,7 +141,7 @@ $unfuck();
 
 window.tumblr.on('navigation', () => requestAnimationFrame(function() {
     $unfuck().catch((e) => {
-        window.setTimeout(() => getCssMapUtilities().then($unfuck), 400)
+        window.setTimeout($unfuck, 400)
     });
 }));
 


### PR DESCRIPTION
This moves the call to `getCssMapUtilities()` to a single use in the top level of the module, allowing one to use `keyToClasses` and `keyToCss` anywhere.

This also ensures that the `window.tumblr.on` call occurs only once the page is loaded enough for `window.tumblr.on` to exist.

Unfortunately, the top level await keyword breaks the eslint setup in tampermonkey's code editor... which is kind of weird, because tampermonkey has a specific checkbox for supporting top level await in scripts, so ideally its linter would work in that case too.

To avoid this, one can wrap the whole script in a function (it just requires either an extra indent on everything or ignoring that and making your indentation a bit weird). See alternate PR.