### PR TITLE
Move CSS map call to wrapper function

### DIFF
--- a/unfucker.js
+++ b/unfucker.js
@@ -13,9 +13,11 @@
 
 'use strict';
 
+getCssMapUtilities().then(({ keyToClasses, keyToCss }) => {
+
 var $ = window.jQuery;
 
-function $unfuck ({ keyToClasses, keyToCss }) {
+async function $unfuck () {
     if ($("#__hw").length) {
         console.log("no need to unfuck");
         return
@@ -135,14 +137,15 @@ function $unfuck ({ keyToClasses, keyToCss }) {
     console.log("dashboard fixed!");
 }
 
-getCssMapUtilities().then($unfuck);
+$unfuck();
 
 window.tumblr.on('navigation', () => requestAnimationFrame(function() {
-    getCssMapUtilities().then($unfuck)
-    .catch((e) => {
+    $unfuck.catch((e) => {
         window.setTimeout(() => getCssMapUtilities().then($unfuck), 400)
     });
 }));
+
+});
 
 async function getCssMapUtilities () {
     let retries = 0;

--- a/unfucker.js
+++ b/unfucker.js
@@ -140,7 +140,7 @@ async function $unfuck () {
 $unfuck();
 
 window.tumblr.on('navigation', () => requestAnimationFrame(function() {
-    $unfuck.catch((e) => {
+    $unfuck().catch((e) => {
         window.setTimeout(() => getCssMapUtilities().then($unfuck), 400)
     });
 }));

--- a/unfucker.js
+++ b/unfucker.js
@@ -141,7 +141,7 @@ $unfuck();
 
 window.tumblr.on('navigation', () => requestAnimationFrame(function() {
     $unfuck().catch((e) => {
-        window.setTimeout(() => getCssMapUtilities().then($unfuck), 400)
+        window.setTimeout($unfuck, 400)
     });
 }));
 


### PR DESCRIPTION
This moves the call to `getCssMapUtilities()` to a single use in a function wrapping the rest of the script, allowing one to use `keyToClasses` and `keyToCss` anywhere.

This also ensures that the `window.tumblr.on` call occurs only once the page is loaded enough for `window.tumblr.on` to exist.

This is incorrectly indented to avoid merge conflicts.