### PR TITLE
Convert remaning removal to display: none

### DIFF
--- a/unfucker.js
+++ b/unfucker.js
@@ -117,7 +117,7 @@ getCssMapUtilities().then(({ keyToClasses, keyToCss }) => {
             $aside.css({marginLeft: "50px", position: "sticky", top: "54px", height: "fit-content"})
             $aside.children().eq(0).css({width: "320px"});
             $(`${keyToCss("about")}${keyToCss("inSidebar")}${keyToCss("usesNewDimensions")}`).css({position: "fixed", height: "20px", bottom: "0px"});
-            $(keyToCss("sidebarItem")).remove();
+            $(keyToCss("sidebarItem")).css("display", "none");
             var $forYou = $(keyToCss("timelineOptionsItemWrapper")).has("a[href='/dashboard/stuff_for_you']");
             var $following = $(keyToCss("timelineOptionsItemWrapper")).has("a[href='/dashboard/following']");
             if ($(keyToCss("timelineOptionsItemWrapper")).first().has("a[href='/dashboard/stuff_for_you']").length ? true : false) {
@@ -173,7 +173,7 @@ getCssMapUtilities().then(({ keyToClasses, keyToCss }) => {
             .add($nav.children().has('use[href="#managed-icon__live-video"]'))
             .add($nav.children().has('use[href="#managed-icon__earth"]'))
             .add($nav.children().has('use[href="#managed-icon__sparkle"]'))
-            .remove();
+            .css("display", "none");
         var $navli = $(`${keyToCss("subNav")} > ${keyToCss("navItem")}, ${keyToCss("accountStats")} li`);
         $navli.on("mouseenter", function() {$(this).css("background-color", "rgba(var(--black),.07)")});
         $navli.on("mouseleave", function() {$(this).css("background-color", "rgb(var(--white))")});

--- a/unfucker.js
+++ b/unfucker.js
@@ -63,7 +63,7 @@ getCssMapUtilities().then(({ keyToClasses, keyToCss }) => {
             }
             ${keyToCss("createPost")} > a { border-radius: 3px !important; }
             @media (max-width: 1150px) {
-                ${keyToCss("buttonInner")} { padding: 8px 16px; }
+                ${keyToCss("navItem")} ${keyToCss("buttonInner")} { padding: 8px 16px !important; }
             }
 
             ${keyToCss("mainContentWrapper")} { display: none !important; }


### PR DESCRIPTION
This fixes resizing around the 1150px breakpoint crashing the site (and the style being messed up below 1150px)!

My guess is the 990px breakpoint will crash pretty much as long as this script moves the nav element into a new DOM container, but maybe that's fixable too; who knows.