### PR TITLE
Fix waitFor function

### DIFF
--- a/unfucker.js
+++ b/unfucker.js
@@ -97,7 +97,6 @@ getCssMapUtilities().then(({ keyToClasses, keyToCss }) => {
     `);
 
     const waitFor = (selector, retried = 0) => new Promise(resolve => {
-        console.log("waitFor", selector, retried);
         $(selector).length
             ? resolve()
             : retried < 25 && requestAnimationFrame(() => waitFor(selector, retried + 1).then(resolve));

--- a/unfucker.js
+++ b/unfucker.js
@@ -97,7 +97,10 @@ getCssMapUtilities().then(({ keyToClasses, keyToCss }) => {
     `);
 
     const waitFor = (selector, retried = 0) => new Promise(resolve => {
-        $(selector).length ? resolve() : retried < 25 && requestAnimationFrame(() => waitFor(selector, retried + 1));
+        console.log("waitFor", selector, retried);
+        $(selector).length
+            ? resolve()
+            : retried < 25 && requestAnimationFrame(() => waitFor(selector, retried + 1).then(resolve));
     });
 
     async function $unfuck () {


### PR DESCRIPTION
Oops... sorry about that. Remember how I said I didn't test my demo code?

This adds a missing `.then(resolve)` to the recursive version of that `waitFor` function.

Should fix #10 for real this time.