### PR TITLE
Prevent eslint warning

### DIFF
--- a/unfucker.js
+++ b/unfucker.js
@@ -11,6 +11,8 @@
 // @require      https://code.jquery.com/jquery-3.6.4.min.js
 // ==/UserScript==
 
+/* globals tumblr */
+
 'use strict';
 
 getCssMapUtilities().then(({ keyToClasses, keyToCss }) => {


### PR DESCRIPTION
This adds a comment that prevents eslint from warning about "tumblr" not being defined (in the tampermonkey editor, for example).

(The comment can go anywhere above the code, so put it wherever.)