### PR TITLE
Refactor obfuscated feature modification

### DIFF
--- a/unfucker.user.js
+++ b/unfucker.user.js
@@ -16,30 +16,34 @@
 
 'use strict';
 
+const modifyOfuscatedFeatures = (obfuscatedFeatures) => {
+    let obf = JSON.parse(atob(obfuscatedFeatures)); // convert from base64, parse from string
+    if (obf.redpopDesktopVerticalNav) {
+        obf.redpopDesktopVerticalNav = false; // disable vertical nav layout
+        obf.liveStreamingWeb = false; // no tumblr live
+    }
+    obf.activityRedesignM3 = false; // ugly activity update
+    obf.liveStreaming = false; // more live shenanigans
+    obf.liveCustomMarqueeData = false;
+    obf.liveStreamingWebPayments = false;
+    obf.adFreeCtaBanner = false; // no annoying popup when using an adblocker
+    obf.domainsSettings = false; // turn off tumblr domains
+    obf.messagingRedesign = false; // disable messaging update
+    obf.experimentalBlockEditorIsOnlyEditor = false; // allow old post editor
+    obf.configurableTabbedDash = true; // new dashboard tab config
+    obf.crowdsignalPollsNpf = true; // poll functionality
+    obf.crowdsignalPollsCreate = true;
+    obf.allowAddingPollsToReblogs = true
+    console.log(obf);
+    return btoa(JSON.stringify(obf)); // compress back to string, convert to base64
+};
+
 if (!window.___INITIAL_STATE___) {
     Object.defineProperty(window, "___INITIAL_STATE___", { // thanks twilight-sparkle-irl!
         set(x) {
             let state = x; // copy state
             try {
-                let obf = JSON.parse(atob(state.obfuscatedFeatures)); // convert from base64, parse from string
-                if (obf.redpopDesktopVerticalNav) {
-                    obf.redpopDesktopVerticalNav = false; // disable vertical nav layout
-                    obf.liveStreamingWeb = false; // no tumblr live
-                }
-                obf.activityRedesignM3 = false; // ugly activity update
-                obf.liveStreaming = false; // more live shenanigans
-                obf.liveCustomMarqueeData = false;
-                obf.liveStreamingWebPayments = false;
-                obf.adFreeCtaBanner = false; // no annoying popup when using an adblocker
-                obf.domainsSettings = false; // turn off tumblr domains
-                obf.messagingRedesign = false; // disable messaging update
-                obf.experimentalBlockEditorIsOnlyEditor = false; // allow old post editor
-                obf.configurableTabbedDash = true; // new dashboard tab config
-                obf.crowdsignalPollsNpf = true; // poll functionality
-                obf.crowdsignalPollsCreate = true;
-                obf.allowAddingPollsToReblogs = true
-                console.log(obf);
-                state.obfuscatedFeatures = btoa(JSON.stringify(obf)); // compress back to string, convert to base64
+                state.obfuscatedFeatures = modifyOfuscatedFeatures(state.obfuscatedFeatures)
             } catch (e) {
                 console.error("Failed to modify features", e)
             } finally {
@@ -56,29 +60,11 @@ if (!window.___INITIAL_STATE___) {
 else {
     let state;
     try {
-        let obf = JSON.parse(atob(window.___INITIAL_STATE___.obfuscatedFeatures)); // convert from base64, parse from string
-        if (obf.redpopDesktopVerticalNav) {
-            obf.redpopDesktopVerticalNav = false; // disable vertical nav layout
-            obf.liveStreamingWeb = false; // no tumblr live
-        }
-        obf.activityRedesignM3 = false; // ugly activity update
-        obf.liveStreaming = false; // more live shenanigans
-        obf.liveCustomMarqueeData = false;
-        obf.liveStreamingWebPayments = false;
-        obf.adFreeCtaBanner = false; // no annoying popup when using an adblocker
-        obf.domainsSettings = false; // turn off tumblr domains
-        obf.messagingRedesign = false; // disable messaging update
-        obf.experimentalBlockEditorIsOnlyEditor = false; // allow old post editor
-        obf.configurableTabbedDash = true; // new dashboard tab config
-        obf.crowdsignalPollsNpf = true; // poll functionality
-        obf.crowdsignalPollsCreate = true;
-        obf.allowAddingPollsToReblogs = true
-        console.log(obf)
-        state = btoa(JSON.stringify(obf));
+        state = modifyOfuscatedFeatures(window.___INITIAL_STATE___.obfuscatedFeatures)
     } catch (e) {
         console.error("Failed to modify features", e)
     } finally {
-        window.unfucked = state; // compress back to string, convert to base64
+        window.unfucked = state;
     }
     Object.defineProperty(window.___INITIAL_STATE___, "obfuscatedFeatures", {
         get() {

--- a/unfucker.user.js
+++ b/unfucker.user.js
@@ -58,13 +58,13 @@ if (!window.___INITIAL_STATE___) {
     });
 }
 else {
-    let state;
+    let obfuscatedFeatures;
     try {
-        state = modifyOfuscatedFeatures(window.___INITIAL_STATE___.obfuscatedFeatures)
+        obfuscatedFeatures = modifyOfuscatedFeatures(window.___INITIAL_STATE___.obfuscatedFeatures)
     } catch (e) {
         console.error("Failed to modify features", e)
     } finally {
-        window.unfucked = state;
+        window.unfucked = obfuscatedFeatures;
     }
     Object.defineProperty(window.___INITIAL_STATE___, "obfuscatedFeatures", {
         get() {

--- a/unfucker.user.js
+++ b/unfucker.user.js
@@ -39,19 +39,18 @@ const modifyOfuscatedFeatures = (obfuscatedFeatures) => {
 };
 
 if (!window.___INITIAL_STATE___) {
+    let state;
     Object.defineProperty(window, "___INITIAL_STATE___", { // thanks twilight-sparkle-irl!
         set(x) {
-            let state = { ...x }; // copy state
+            state = { ...x }; // copy state
             try {
                 state.obfuscatedFeatures = modifyOfuscatedFeatures(state.obfuscatedFeatures)
             } catch (e) {
                 console.error("Failed to modify features", e)
-            } finally {
-                window.unfucked = state; // save to proxy variable
             }
         },
         get() {
-            return window.unfucked; // return proxy variable
+            return state;
         },
         enumerable: true,
         configurable: true
@@ -63,12 +62,10 @@ else {
         obfuscatedFeatures = modifyOfuscatedFeatures(window.___INITIAL_STATE___.obfuscatedFeatures)
     } catch (e) {
         console.error("Failed to modify features", e)
-    } finally {
-        window.unfucked = obfuscatedFeatures;
     }
     Object.defineProperty(window.___INITIAL_STATE___, "obfuscatedFeatures", {
         get() {
-            return window.unfucked; // return proxy variable
+            return obfuscatedFeatures;
         },
         enumerable: true,
         configurable: true

--- a/unfucker.user.js
+++ b/unfucker.user.js
@@ -41,7 +41,7 @@ const modifyOfuscatedFeatures = (obfuscatedFeatures) => {
 if (!window.___INITIAL_STATE___) {
     Object.defineProperty(window, "___INITIAL_STATE___", { // thanks twilight-sparkle-irl!
         set(x) {
-            let state = x; // copy state
+            let state = { ...x }; // copy state
             try {
                 state.obfuscatedFeatures = modifyOfuscatedFeatures(state.obfuscatedFeatures)
             } catch (e) {


### PR DESCRIPTION
No functional changes here, and feel free not to merge this or to just take parts of it. Just some code cleanup suggestions! This:

- Extracts the "obf" modification into a function (I tried to steal this code to test a feature flag, only changed it in one of the locations, and got confused :D)
- Demonstrates javascript object shallow copying using `{ ...spread }` syntax (technically the code was mutating the input to the getter before, although this evidently causes no problems). Good practice, though!
- Demonstrates that you don't have to use a window global to store stuff for later!