### PR TITLE
Wrap `setTimeout` callback inside an anonymous function

### DIFF
--- a/unfucker.user.js
+++ b/unfucker.user.js
@@ -770,14 +770,14 @@ const main = async function () {
           <option value="${windowWidth}" label="full width"></option>
         `;
       });
-      window.tumblr.on('navigation', () => window.setTimeout(
+      window.tumblr.on('navigation', () => window.setTimeout(() => {
         unfuck().then(() => {
           window.setTimeout(() => {
             if (!$a("#__m").length) unfuck();
           }, 400)
         }).catch((e) =>
           window.setTimeout(unfuck, 400)
-        ), 400
+        )}, 400
       ));
     });
   });


### PR DESCRIPTION
We are seeing a bunch of `Unexpected identifier 'Promise'` errors at Tumblr, wrapping the callback will silence them.