### PR TITLE
Fixed avatar scaling on high dpi

### DIFF
--- a/unfucker.user.js
+++ b/unfucker.user.js
@@ -768,7 +768,10 @@ const main = async function (nonce) {
                     <div class="__placeholder" style="padding-bottom: 100%;">
                       <img
                       class="__avatarImage"
-                      srcset="https://api.tumblr.com/v2/blog/${name}/avatar/64 64w, https://api.tumblr.com/v2/blog/${name}/avatar/96 96w"
+                      srcset="https://api.tumblr.com/v2/blog/${name}/avatar/64 64w,
+                              https://api.tumblr.com/v2/blog/${name}/avatar/96 96w,
+                              https://api.tumblr.com/v2/blog/${name}/avatar/128 128w,
+                              https://api.tumblr.com/v2/blog/${name}/avatar/512 512w"
                       sizes="64px"
                       alt="${tr("Avatar")}" 
                       style="width: 64px; height: 64px;" 
@@ -1178,6 +1181,7 @@ const main = async function (nonce) {
               mutationManager.start(fixHeaderAvatar, postHeaderTargetSelector);
             }
             else {
+              $a(`.__stickyContainer > ${keyToCss('avatar')} img`).forEach(img => img.sizes = "32px");
               $a(`.__stickyContainer > ${keyToCss('avatar')}`).forEach(avatar => avatar.closest('article').querySelector('header').prepend(avatar));
               remove($a('.__stickyContainer, .__userAvatarWrapper'));
               $a('.__headerFixed').forEach(elem => elem.classList.remove('__headerFixed'));

--- a/unfucker.user.js
+++ b/unfucker.user.js
@@ -768,8 +768,8 @@ const main = async function (nonce) {
                     <div class="__placeholder" style="padding-bottom: 100%;">
                       <img
                       class="__avatarImage"
-                      src="https://api.tumblr.com/v2/blog/${name}/avatar"
-                      sizes="64px" 
+                      srcset="https://api.tumblr.com/v2/blog/${name}/avatar/64 64w, https://api.tumblr.com/v2/blog/${name}/avatar/96 96w"
+                      sizes="64px"
                       alt="${tr("Avatar")}" 
                       style="width: 64px; height: 64px;" 
                       loading="eager">
@@ -790,6 +790,7 @@ const main = async function (nonce) {
             post.prepend(stickyContainer);
             stickyContainer.append(avatar);
             post.classList.add('__avatarFixed');
+            avatar.querySelector('img').sizes = "64px";
           } catch (e) {
             console.error('an error occurred processing a post avatar:', e);
             console.error(post);


### PR DESCRIPTION
The floating post avatars are moved from the small avatar used in the post. This means they keep the `sizes="32px"` attribute and render at a very low resolution. This is especially noticeable on high dpi displays. I added a line to modify it to `"64px"`, which should be the correct value for its actual size.

This also applies to the user avatar at the top of the dashboard, because it has a hardcoded Tumblr Api link to a 64x64 image. I changed it to also include a 96x96 version in `srcset`. (maybe we should include all of the available sizes up to 512?)

PS: this solution might be a bit bad, because i don't fully understand how the `sizes` and `srcset` attributes work.